### PR TITLE
Add repository URL to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ test = [
   "setuptools>=45",
 ]
 
+[project.urls]
+Repository = "https://github.com/wenkokke/py-tree-sitter-type-provider"
+
 [tool.bumpver]
 current_version = "2.2.0"
 version_pattern = "MAJOR.MINOR.PATCH"


### PR DESCRIPTION
Currently, the only link from the project's [PyPI page](https://pypi.org/project/tree-sitter-type-provider/) to its source repo is its GitHub Actions badge, which isn't very convenient.

This adds the repo URL as a [project URL](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls) in `pyproject.toml`, allowing it to be [displayed as such on PyPI](https://docs.pypi.org/project_metadata/).